### PR TITLE
Gdpr banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,24 @@
-import React, { FC, ReactElement, useContext } from 'react';
-import { BrowserRouter } from 'react-router-dom';
-import './App.scss';
-import { AuthContext } from './context/authContext';
-import AppRoute from './routes/appRoutes';
-import AuthRoute from './routes/authRoutes';
+import React, { FC, ReactElement, useContext } from "react";
+import { BrowserRouter } from "react-router-dom";
+import "./App.scss";
+import { AuthContext } from "./context/authContext";
+import AppRoute from "./routes/appRoutes";
+import AuthRoute from "./routes/authRoutes";
+import GDPRBanner from "./components/gdpr/Banner";
 
 const App: FC = (): ReactElement => {
+  const authValue = useContext(AuthContext);
 
-  const authValue = useContext(AuthContext)
-
-  console.log("AUTH CONTEXT:::", authValue)
+  console.log("AUTH CONTEXT:::", authValue);
 
   return (
     <div className=" App " data-testid="app">
       <BrowserRouter>
-        {
-          authValue && authValue.token ?
-            <AppRoute /> :
-            <AuthRoute />
-        }
+        {authValue && authValue.token ? <AppRoute /> : <AuthRoute />}
       </BrowserRouter>
+      <GDPRBanner />
     </div>
   );
-}
+};
 
 export default App;

--- a/src/components/gdpr/Banner.tsx
+++ b/src/components/gdpr/Banner.tsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from "react";
+import { Button, Container, Row, Col } from "react-bootstrap";
+
+const GDPRBanner: React.FC = () => {
+  const [showBanner, setShowBanner] = useState<boolean>(true);
+
+  useEffect(() => {
+    const hasAccepted = localStorage.getItem("gdpr_accepted");
+    if (hasAccepted) {
+      setShowBanner(false);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem("gdpr_accepted", "true");
+    setShowBanner(false);
+  };
+
+  return (
+    <>
+      {showBanner && (
+        <div
+          className="fixed-bottom p-2 text-white"
+          style={{
+            zIndex: 9999,
+            boxShadow: "0px 0px 8px rgba(0, 0, 0, 0.3)",
+            background: "#0A4D68",
+          }}
+        >
+          <Container>
+            <Row>
+              <Col>
+                <span
+                  style={{
+                    marginRight: "10px",
+                    fontWeight: "bold",
+                    fontSize: "14px",
+                  }}
+                >
+                  This website uses cookies to improve your experience. By
+                  clicking "Accept", you consent to the use of all cookies in
+                  accordance with GDPR.
+                </span>
+              </Col>
+              <Col xs="auto">
+                <Button
+                  variant="light"
+                  onClick={handleAccept}
+                  style={{ fontSize: "14px" }}
+                >
+                  Accept
+                </Button>
+              </Col>
+            </Row>
+          </Container>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default GDPRBanner;

--- a/src/components/gdpr/Banner.tsx
+++ b/src/components/gdpr/Banner.tsx
@@ -29,13 +29,7 @@ const GDPRBanner: React.FC = () => {
         >
           <Container>
             <Row>
-              <Col
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
+              <Col className="d-flex align-items-center justify-content-center">
                 <span
                   style={{
                     marginRight: "10px",

--- a/src/components/gdpr/Banner.tsx
+++ b/src/components/gdpr/Banner.tsx
@@ -29,7 +29,13 @@ const GDPRBanner: React.FC = () => {
         >
           <Container>
             <Row>
-              <Col>
+              <Col
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
                 <span
                   style={{
                     marginRight: "10px",


### PR DESCRIPTION
## Description

This PR adds a GDPR banner component that uses local storage to store the acceptance of cookies.

The component displays a banner at the bottom of the page with a message about the use of cookies on the website. The user can click the "Accept" button to hide the banner and store their acceptance of cookies in local storage. If the user has already accepted cookies, the banner is not displayed.

## Changes

- Added `GDPRBanner` component that displays a banner at the bottom of the page with a message about cookies
- Added state to track whether the banner should be displayed (`showBanner`)
- Added `useEffect` hook to check if the user has already accepted cookies using local storage
- Added `handleAccept` function to set the `gdpr_accepted` key in local storage and hide the banner when the user accepts cookies
- Added Bootstrap styling to the banner for responsiveness and readability

## Testing

- Tested the component in a local development environment
- Verified that the banner is displayed when the user has not accepted cookies and hidden when they have
- Verified that the acceptance of cookies is stored in local storage
- Tested the component on multiple devices and browsers to ensure responsiveness and readability.

## Screeshot

![image](https://user-images.githubusercontent.com/31920073/233860629-14b781ba-2a04-4b98-8285-53815432915f.png)


